### PR TITLE
update restoreBackup action

### DIFF
--- a/data/UKM/actions/restorebackup
+++ b/data/UKM/actions/restorebackup
@@ -184,9 +184,9 @@ case "$1" in
 	;;
 	
 	restart)
-		am force-stop com.af.synapse 2> /dev/null;
-		$BB usleep 100000;
 		reset_uci;
+		$BB usleep 100000;
+		am force-stop com.af.synapse 2> /dev/null;
 		$BB usleep 100000;
 		am start -a android.intent.action.MAIN -n com.af.synapse/.MainActivity 2> /dev/null;
 	;;


### PR DESCRIPTION
Change Reset function to reset UCI then force stop activity and restart. This avoids the awkward two second wait while synapse is closed.
